### PR TITLE
[IT-4665] Sleep for a second between calls to lamda-mips-api

### DIFF
--- a/floqast_sftp/app.py
+++ b/floqast_sftp/app.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import logging
+import time
 from datetime import date, datetime
 
 import boto3
@@ -317,6 +318,7 @@ def lambda_handler(event, context):
             name, file_obj = get_balances_csv(url)
             put_sftp_file(client, name, file_obj)
             period = get_previous_month(period)
+            time.sleep(1)
     finally:
         # Always close the SFTP session and transport
         client.close()


### PR DESCRIPTION
Add a short sleep (1s) between calls to lambda-mips-api in an attempt to address an issue with lambda-mips-api sporadically failing to log out.
