### PR TITLE
[IT-4949] Add SigV4 signing for IAM-authenticated API access

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
     -   id: yamllint
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v1.45.0
+    rev: v1.48.1
     hooks:
     -   id: cfn-python-lint
         files: template\.(json|yml|yaml)$
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: j2lint
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.1.0
+    rev: 26.3.1
     hooks:
     - id: black
       language_version: python3.12

--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,10 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pytest = "~=7.1"
-pytest-mock = "~=3.8"
+pytest = "~=9.0"
+pytest-mock = "~=3.15"
 requests-mock = "~=1.10"
-paramiko-mock = "~=1.0"
+paramiko-mock = "~=2.0"
 boto3 = "~=1.24"
 coverage = "~=7.3"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ed5182bd2c25b2b08bc280eace2d07bbd887a4ae861283b7492a148364485168"
+            "sha256": "46f77505d059d3e3df0397292b29608dd5b9f50d4e0060fcd6d59f79ef3f6bc4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -954,10 +954,12 @@
         },
         "paramiko-mock": {
             "hashes": [
-                "sha256:c5531019d18fd3bf8e0d3fb34f22b56f16ec1be79e11979403e169f9ebb12618"
+                "sha256:163ee2e33ded6e29d2769205ebcb7cefc29b156fe7250a90283f41942f40a0d0",
+                "sha256:ea496f6e61549f89bb37c7d48b63843d675b41e6ad8ea80865c5b085f3ccdc85"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "markers": "python_version >= '3.10'",
+            "version": "==2.0.1"
         },
         "pluggy": {
             "hashes": [
@@ -974,6 +976,14 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==3.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+                "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.20.0"
         },
         "pynacl": {
             "hashes": [
@@ -1008,12 +1018,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280",
-                "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"
+                "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9",
+                "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==7.4.4"
+            "markers": "python_version >= '3.10'",
+            "version": "==9.0.3"
         },
         "pytest-mock": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ with the current month and moving backwards. A separate CSV file will be fetched
 for each activity period, and uploaded to the specified SFTP server with a unique
 file name.
 
+### IAM Authentication
+
+The lambda-mips-api /balances endpoint requires AWS IAM authentication. When
+`MipApiRegion` is provided, this lambda signs HTTP requests with SigV4 using
+botocore. The `MipApiExecuteArn` parameter must be configured with the execute-api
+ARN for the /balances endpoint to allow the lambda to invoke it.
+
+If `MipApiRegion` is not provided, requests are sent unsigned (backward-compatible
+behavior for testing or non-IAM environments).
+
 ## Parameters
 
 ### SSM Parameters
@@ -40,9 +50,12 @@ The following template parameters are used to configure behavior:
 
 | Template Parameter | Type                            | Default               | Description                                                                                        |
 |---------------------|---------------------------------|-----------------------|----------------------------------------------------------------------------------------------------|
-| Schedule            | EventBridge Schedule Expression | `cron(30 10 2 * ? *)` | EventBridge schedule for running the lambda                                                        |
+| Schedule            | EventBridge Schedule Expression | `cron(0 4 ? * MON *)` | EventBridge schedule for running the lambda                                                        |
 | SsmPrefix           | String                          | /floqast-sftp         | Prepend this value to the SSM parameter keys                                                       |
 | PeriodCount         | Number                          | 2                     | The number of activity periods (months) to report on, starting at the present and moving backwards |
+| MipApiBalances      | String                          | ""                    | API Gateway URL to lambda-mips-api /balances endpoint (required for IAM auth, not CloudFront)     |
+| MipApiRegion        | String                          | us-east-1             | AWS region of lambda-mips-api API Gateway (used for SigV4 request signing)                        |
+| MipApiExecuteArn    | String                          | ""                    | ARN for execute-api:Invoke on mips-api /balances endpoint (required for IAM policy)               |
 
 
 ## Development

--- a/floqast_sftp/app.py
+++ b/floqast_sftp/app.py
@@ -6,6 +6,8 @@ from datetime import date, datetime
 
 import boto3
 import paramiko
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
 
 import requests
 
@@ -13,6 +15,7 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)
 
 ssm_client = None
+_session = boto3.Session()
 
 
 def get_event_param(event, param):
@@ -217,14 +220,42 @@ def get_csv_url(event, when):
     return full_url
 
 
-def get_balances_csv(url):
+def sign_request(url, region):
+    """
+    Sign an HTTP GET request with SigV4 for IAM-authenticated API Gateway access.
+
+    Parameters
+    ----------
+    url: str
+        The full URL to sign.
+
+    region: str
+        AWS region of the API Gateway (e.g. 'us-east-1').
+
+    Returns
+    -------
+    dict
+        HTTP headers containing the SigV4 authorization signature.
+    """
+    credentials = _session.get_credentials().get_frozen_credentials()
+    aws_request = AWSRequest(method="GET", url=url)
+    SigV4Auth(credentials, "execute-api", region).add_auth(aws_request)
+    return dict(aws_request.headers)
+
+
+def get_balances_csv(url, region=None):
     """
     Fetch the balances CSV from lambda-mips-api for the given activity period.
+    If a region is provided, the request will be signed with SigV4 for
+    IAM-authenticated API Gateway access.
 
     Parameters
     ----------
     url: str
         URL to lambda-mips-api balances endpoint
+
+    region: str, optional
+        AWS region for SigV4 signing. If None, request is unsigned.
 
     Returns
     -------
@@ -232,8 +263,8 @@ def get_balances_csv(url):
         Tuple of file name and a file-like object.
 
     """
-    # get url and create file object from response
-    response = requests.get(url, stream=True)
+    headers = sign_request(url, region) if region else {}
+    response = requests.get(url, headers=headers, stream=True)
     response.raise_for_status()
     file_obj = io.StringIO(response.text)
 
@@ -311,11 +342,13 @@ def lambda_handler(event, context):
 
     # Start with today, and go back N months
     try:
+        # Get the API region for SigV4 signing (optional)
+        api_region = event.get("mip_api_region")
         period = date.today()
         for _ in range(period_count):
             when = period.isoformat()
             url = get_csv_url(event, when)
-            name, file_obj = get_balances_csv(url)
+            name, file_obj = get_balances_csv(url, region=api_region)
             put_sftp_file(client, name, file_obj)
             period = get_previous_month(period)
             time.sleep(1)

--- a/template.yaml
+++ b/template.yaml
@@ -40,14 +40,27 @@ Parameters:
       The number of 1-month activity periods to query for trial balances.
   MipApiBalances:
     Type: String
-    Default: "https://mips-api.finops.sageit.org/balances"
+    Default: ""
     Description: >-
-      The URL to the balances endpoint of lambda-mips-api.
+      The API Gateway URL to the balances endpoint of lambda-mips-api.
+      Must be the API Gateway execute-api URL (not CloudFront) for IAM auth.
+      Example: https://API_ID.execute-api.us-east-1.amazonaws.com/Prod/balances
+  MipApiRegion:
+    Type: String
+    Default: "us-east-1"
+    Description: >-
+      The AWS region of the lambda-mips-api API Gateway.
+      Used for SigV4 request signing.
   SsmPrefix:
     Type: String
     Default: '/floqast-sftp'
     Description: >-
       Prefix for SSM parameter paths for SFTP authentication secrets
+  MipApiExecuteArn:
+    Type: String
+    Description: >-
+      ARN for execute-api:Invoke on the mips-api API Gateway /balances endpoint.
+      Format: arn:aws:execute-api:REGION:ACCOUNT:API_ID/STAGE/GET/balances
   KmsKeyAdminArns:
     Type: CommaDelimitedList
     Description: List of role ARNs to manage the encryption key
@@ -77,6 +90,7 @@ Resources:
                 ssm_secret_prefix: !Ref SsmPrefix
                 period_count: !Ref PeriodCount
                 mip_api_balances_url: !Ref MipApiBalances
+                mip_api_region: !Ref MipApiRegion
 
   FunctionRole:   # execute lambda function with this role
     Type: AWS::IAM::Role
@@ -100,6 +114,10 @@ Resources:
               - Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SsmPrefix}'
                 Action:
                   - 'ssm:GetParameter*'
+                Effect: Allow
+              - Resource: !Ref MipApiExecuteArn
+                Action:
+                  - 'execute-api:Invoke'
                 Effect: Allow
 
   # Key for encrypting our secret parameter
@@ -153,9 +171,6 @@ Resources:
       AliasName: !Sub 'alias/${KmsAliasPrefix}-key'
 
 Outputs:
-  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
-  # Find out more about other implicit resources you can reference within SAM
-  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   FloQastSftpFunctionArn:
     Description: "FloQast SFTP Lambda Function ARN"
     Value: !GetAtt FloQastSftpFunction.Arn


### PR DESCRIPTION
The lambda-mips-api /balances endpoint now requires IAM authentication. Update this lambda to sign HTTP requests with SigV4 using botocore when an API region is provided in the event payload.

Template changes:
- Add MipApiRegion parameter for SigV4 signing.
- Add MipApiExecuteArn parameter for IAM policy.
- Add execute-api:Invoke permission scoped to the mips-api /balances endpoint.
- Update MipApiBalances default and description to reflect API Gateway URL requirement.

Code changes:
- Add sign_request() function using botocore SigV4Auth to sign requests with the lambda execution role.
- Update get_balances_csv() to accept optional region parameter. Backward-compatible: unsigned if no region is provided.

No new dependencies; botocore is available via boto3.
